### PR TITLE
Handle .git location for submodules

### DIFF
--- a/src/commit-message.js
+++ b/src/commit-message.js
@@ -8,7 +8,6 @@ function commitMessage() {
   var commitMsgFile = filename;
   if(!fileInfo('./.git').isDirectory()) {
     var unparsedText = "" + read('./.git');
-    console.log("ParsedText: " + unparsedText.substring('gitdir: '.length).trim());
     commitMsgFile = unparsedText.substring('gitdir: '.length).trim() + '/COMMIT_EDITMSG';
   }
 


### PR DESCRIPTION
  If .git is actually a file and not a directory, we're in a submodule and .git is actually a 'pointer' file that tells us where the actual .git dir contents are.

  This change checks to see if the file is a directory and, if it's not, naively loads the contents of the file assuming it only contains 'gitdir: <directory location>'
